### PR TITLE
5.0+1.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,8 @@ plugins {
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-archivesBaseName = "${project.mod_id}-${project.supported_versions}"
-version = project.mod_version
+archivesBaseName = project.mod_id
+version = "${project.mod_version}+${project.supported_versions}"
 group = project.maven_group
 
 repositories {
@@ -46,6 +43,9 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 java {
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.
 	// If you remove this line, sources will not be generated.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
 	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
-	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
 archivesBaseName = project.mod_id

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ plugins {
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 archivesBaseName = "${project.mod_id}-${project.supported_versions}"
 version = project.mod_version
 group = project.maven_group
@@ -34,8 +37,12 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	// it.options.release = 17
+	it.options.encoding = "UTF-8"
+
+	def targetVersion = 8
+	if (JavaVersion.current().isJava9Compatible()) {
+		it.options.release = targetVersion
+	}
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -8,17 +8,13 @@ version = "${project.mod_version}+${project.supported_versions}"
 group = project.maven_group
 
 repositories {
-	// Add repositories to retrieve artifacts from in here.
-	// You should only use this when depending on other mods because
-	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
-	// for more information about repositories.
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	mappings "dev.tildejustin:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,60 +1,74 @@
 plugins {
-	alias libs.plugins.fabric.loom
-	id "maven-publish"
+	id 'fabric-loom' version '1.4-SNAPSHOT'
+	id 'maven-publish'
+	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
-version = "$mod_version+$target_version"
-group = maven_group
-
-base {
-	archivesName = archives_name
-}
+archivesBaseName = "${project.mod_id}-${project.supported_versions}"
+version = project.mod_version
+group = project.maven_group
 
 repositories {
-	maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-	maven { url "https://jitpack.io" }
-}
-
-loom {
-	decompilers {
-		vineflower {
-			options.putAll(["mark-corresponding-synthetics": "1", "ind": "    "])
-		}
-	}
-	mixin {
-		useLegacyMixinAp = false
-	}
+	// Add repositories to retrieve artifacts from in here.
+	// You should only use this when depending on other mods because
+	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
+	// for more information about repositories.
 }
 
 dependencies {
-	minecraft libs.minecraft
-	mappings variantOf(libs.yarn.mappings) { classifier "v2" }
-	modImplementation libs.fabric.loader
-	vineflowerDecompilerClasspath libs.vineflower
+	// To change the versions see the gradle.properties file
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 }
 
 processResources {
-	filesMatching "fabric.mod.json", {
-		expand "version": version
+	inputs.property "mod_id", project.mod_id
+	inputs.property "version", project.version
+	filteringCharset "UTF-8"
+
+	filesMatching("fabric.mod.json") {
+		expand "mod_id": project.mod_id, "version": project.version
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.encoding = "UTF-8"
-	if (JavaVersion.current().isJava9Compatible()) it.options.release.set(8)
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	// it.options.release = 17
 }
 
 java {
-	sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
 }
 
 jar {
-	from "LICENSE"
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}" }
+	}
 }
 
+// configure the maven publication
 publishing {
-	publications.create("mavenJava", MavenPublication) {
-		from components.java
+	publications {
+		mavenJava(MavenPublication) {
+			artifact(remapJar) {
+				builtBy remapJar
+			}
+			artifact(sourcesJar) {
+				builtBy remapSourcesJar
+			}
+		}
 	}
-	repositories {}
+
+	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+	repositories {
+		// Add repositories to publish to here.
+		// Notice: This block does NOT have the same function as the block in the top level.
+		// The repositories here will be used for publishing your artifact, not for
+		// retrieving dependencies.
+	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.1+build.21
 loader_version=0.15.0
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=5.0.0
 maven_group=me.wurgo
 archives_base_name=antiresourcereload
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
+yarn_mappings=1.16.1-build.24
 loader_version=0.15.0
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,17 @@
-org.gradle.jvmargs = -Xmx2G
-org.gradle.parallel = true
-org.gradle.caching = true
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx2G
 
-mod_version = 4.0.1
-target_version = 1.16.1
-archives_name = antiresourcereload
-maven_group = me.wurgo
+# Fabric Properties
+# check these on https://fabricmc.net/develop
+minecraft_version=1.16.1
+yarn_mappings=1.16.1+build.21
+loader_version=0.15.0
+
+# Mod Properties
+mod_version=1.3.0
+maven_group=me.wurgo
+archives_base_name=antiresourcereload
+
+# MCSR
+mod_id=antiresourcereload
+supported_versions=1.16.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -1,8 +1,6 @@
 package me.wurgo.antiresourcereload;
 
 import com.google.gson.JsonElement;
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -11,19 +11,14 @@ import org.apache.logging.log4j.Logger;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class AntiResourceReload implements ModInitializer {
-    private static final Logger LOGGER = LogManager.getLogger(FabricLoader.getInstance().getModContainer("antiresourcereload").get().getMetadata().getName());
-
-    public static void log(String message) {
-        LOGGER.info("[" + LOGGER.getName() + "] " + message);
-    }
+public class AntiResourceReload {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     public static CompletableFuture<ServerResourceManager> cache;
     public static Map<Identifier, JsonElement> recipes;
     public static boolean hasSeenRecipes;
 
-    @Override
-    public void onInitialize() {
-        log("Initializing.");
+    public static void log(String message) {
+        LOGGER.info("[AntiResourceReload] " + message);
     }
 }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin {
@@ -36,7 +37,7 @@ public abstract class MinecraftClientMixin {
             )
     )
     private CompletableFuture<ServerResourceManager> cachedReload(List<ResourcePack> dataPacks, CommandManager.RegistrationEnvironment registrationEnvironment, int i, Executor executor, Executor executor2, Operation<CompletableFuture<ServerResourceManager>> original, @Local ResourcePackManager<ResourcePackProfile> resourcePackManager) throws ExecutionException, InterruptedException {
-        boolean usingDataPacks = !resourcePackManager.getEnabledProfiles().stream().map(ResourcePackProfile::getName).toList().equals(DataPackSettings.SAFE_MODE.getEnabled());
+        boolean usingDataPacks = !resourcePackManager.getEnabledProfiles().stream().map(ResourcePackProfile::getName).collect(Collectors.toList()).equals(DataPackSettings.SAFE_MODE.getEnabled());
         if (usingDataPacks) {
             AntiResourceReload.log("Using data-packs, reloading.");
         } else if (AntiResourceReload.cache == null) {

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -12,7 +12,9 @@ import net.minecraft.tag.BlockTags;
 import net.minecraft.tag.EntityTypeTags;
 import net.minecraft.tag.FluidTags;
 import net.minecraft.tag.ItemTags;
+import net.minecraft.util.profiler.Profiler;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.List;
@@ -22,6 +24,9 @@ import java.util.concurrent.Executor;
 
 @Mixin(MinecraftClient.class)
 public abstract class MinecraftClientMixin {
+
+    @Shadow
+    private Profiler profiler;
 
     @WrapOperation(
             method = "method_29604",
@@ -39,9 +44,10 @@ public abstract class MinecraftClientMixin {
         } else {
             AntiResourceReload.log("Using cached server resources.");
             if (AntiResourceReload.hasSeenRecipes) {
-                ((RecipeManagerAccess) AntiResourceReload.cache.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
+                ServerResourceManager manager = AntiResourceReload.cache.get();
+                ((RecipeManagerAccess) manager.getRecipeManager()).invokeApply(AntiResourceReload.recipes, manager.getResourceManager(), this.profiler);
+                AntiResourceReload.hasSeenRecipes = false;
             }
-            AntiResourceReload.hasSeenRecipes = false;
             return AntiResourceReload.cache;
         }
 

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -30,7 +30,7 @@ public abstract class MinecraftClientMixin {
     private Profiler profiler;
 
     @WrapOperation(
-            method = "method_29604",
+            method = "createIntegratedResourceManager",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/resource/ServerResourceManager;reload(Ljava/util/List;Lnet/minecraft/server/command/CommandManager$RegistrationEnvironment;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -44,7 +44,9 @@ public abstract class MinecraftClientMixin {
             AntiResourceReload.log("Cached resources unavailable, reloading & caching.");
         } else {
             AntiResourceReload.log("Using cached server resources.");
-            if (AntiResourceReload.hasSeenRecipes) {
+            // only reload recipes on the main thread
+            // this is for compat with seedqueue creating servers in the background
+            if (MinecraftClient.getInstance().isOnThread() && AntiResourceReload.hasSeenRecipes) {
                 ServerResourceManager manager = AntiResourceReload.cache.get();
                 ((RecipeManagerAccess) manager.getRecipeManager()).invokeApply(AntiResourceReload.recipes, manager.getResourceManager(), this.profiler);
                 AntiResourceReload.hasSeenRecipes = false;

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/MinecraftClientMixin.java
@@ -1,13 +1,19 @@
 package me.wurgo.antiresourcereload.mixin;
 
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import me.wurgo.antiresourcereload.AntiResourceReload;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.resource.*;
 import net.minecraft.server.command.CommandManager;
-import org.spongepowered.asm.mixin.*;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.tag.EntityTypeTags;
+import net.minecraft.tag.FluidTags;
+import net.minecraft.tag.ItemTags;
+import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -15,21 +21,22 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 @Mixin(MinecraftClient.class)
-public class MinecraftClientMixin {
-    @Unique
-    private boolean hasLoadedTags;
+public abstract class MinecraftClientMixin {
 
-    @Redirect(
-            method = "createIntegratedResourceManager",
+    @WrapOperation(
+            method = "method_29604",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/resource/ServerResourceManager;reload(Ljava/util/List;Lnet/minecraft/server/command/CommandManager$RegistrationEnvironment;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"
             )
     )
-    private CompletableFuture<ServerResourceManager> antiresourcereload_cachedReload(List<ResourcePack> dataPacks, CommandManager.RegistrationEnvironment registrationEnvironment, int i, Executor executor, Executor executor2) throws ExecutionException, InterruptedException {
-        if (dataPacks.size() != 1) { AntiResourceReload.log("Using data-packs, reloading."); }
-        else if (AntiResourceReload.cache == null) { AntiResourceReload.log("Cached resources unavailable, reloading & caching."); }
-        else {
+    private CompletableFuture<ServerResourceManager> cachedReload(List<ResourcePack> dataPacks, CommandManager.RegistrationEnvironment registrationEnvironment, int i, Executor executor, Executor executor2, Operation<CompletableFuture<ServerResourceManager>> original, @Local ResourcePackManager<ResourcePackProfile> resourcePackManager) throws ExecutionException, InterruptedException {
+        boolean usingDataPacks = !resourcePackManager.getEnabledProfiles().stream().map(ResourcePackProfile::getName).toList().equals(DataPackSettings.SAFE_MODE.getEnabled());
+        if (usingDataPacks) {
+            AntiResourceReload.log("Using data-packs, reloading.");
+        } else if (AntiResourceReload.cache == null) {
+            AntiResourceReload.log("Cached resources unavailable, reloading & caching.");
+        } else {
             AntiResourceReload.log("Using cached server resources.");
             if (AntiResourceReload.hasSeenRecipes) {
                 ((RecipeManagerAccess) AntiResourceReload.cache.get().getRecipeManager()).invokeApply(AntiResourceReload.recipes, null, null);
@@ -38,25 +45,25 @@ public class MinecraftClientMixin {
             return AntiResourceReload.cache;
         }
 
-        CompletableFuture<ServerResourceManager> reloaded = ServerResourceManager.reload(dataPacks, registrationEnvironment, i, executor, executor2);
+        CompletableFuture<ServerResourceManager> reloaded = original.call(dataPacks, registrationEnvironment, i, executor, executor2);
         
-        if (dataPacks.size() == 1) { AntiResourceReload.cache = reloaded; }
-
+        if (!usingDataPacks) {
+            AntiResourceReload.cache = reloaded;
+        }
         return reloaded;
     }
 
-    @Redirect(
+    @WrapWithCondition(
             method = "startIntegratedServer(Ljava/lang/String;Lnet/minecraft/util/registry/RegistryTracker$Modifiable;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function4;ZLnet/minecraft/client/MinecraftClient$WorldLoadAction;)V",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/resource/ServerResourceManager;loadRegistryTags()V"
             )
     )
-    private void antiresourcereload_skipLoad(ServerResourceManager manager) throws ExecutionException, InterruptedException {
-        if (AntiResourceReload.cache != null && manager == AntiResourceReload.cache.get()) {
-            if (hasLoadedTags) return;
-            hasLoadedTags = true;
-        }
-        manager.loadRegistryTags();
+    private boolean skipReloadingRegistryTags(ServerResourceManager manager) {
+        return manager.getRegistryTagManager().blocks() != BlockTags.getContainer() ||
+                manager.getRegistryTagManager().items() != ItemTags.getContainer() ||
+                manager.getRegistryTagManager().fluids() != FluidTags.getContainer() ||
+                manager.getRegistryTagManager().entityTypes() != EntityTypeTags.getContainer();
     }
 }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeBookWidgetMixin.java
@@ -8,9 +8,12 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RecipeBookWidget.class)
-public class RecipeBookWidgetMixin {
-    @Inject(method = "initialize", at = @At("HEAD"))
-    public void antiresourcereload_updateHasSeenRecipes(CallbackInfo ci){
+public abstract class RecipeBookWidgetMixin {
+    @Inject(
+            method = "initialize",
+            at = @At("HEAD")
+    )
+    private void updateHasSeenRecipes(CallbackInfo ci) {
         AntiResourceReload.hasSeenRecipes = true;
     }
 }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeManagerMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/RecipeManagerMixin.java
@@ -14,12 +14,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.Map;
 
 @Mixin(RecipeManager.class)
-public class RecipeManagerMixin {
+public abstract class RecipeManagerMixin {
     @Inject(
             method = "apply(Ljava/util/Map;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/util/profiler/Profiler;)V",
             at = @At("HEAD")
     )
-    private void antiresourcereload_setRecipes(Map<Identifier, JsonElement> map, ResourceManager resourceManager, Profiler profiler, CallbackInfo ci) {
+    private void setRecipes(Map<Identifier, JsonElement> map, ResourceManager resourceManager, Profiler profiler, CallbackInfo ci) {
         if (AntiResourceReload.cache != null && !AntiResourceReload.cache.isDone()) {
             AntiResourceReload.recipes = map;
         }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/ServerResourceManagerMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/ServerResourceManagerMixin.java
@@ -1,27 +1,25 @@
 package me.wurgo.antiresourcereload.mixin;
 
 import me.wurgo.antiresourcereload.AntiResourceReload;
-import net.minecraft.resource.ReloadableResourceManager;
 import net.minecraft.resource.ServerResourceManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.concurrent.ExecutionException;
 
 @Mixin(ServerResourceManager.class)
 public abstract class ServerResourceManagerMixin {
-    @Redirect(
+    @Inject(
             method = "close",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/resource/ReloadableResourceManager;close()V"
-            )
+            at = @At("HEAD"),
+            cancellable = true
     )
-    private void antiresourcereload_keepOpened(ReloadableResourceManager instance) throws ExecutionException, InterruptedException {
+    private void keepCachedResourcesOpen(CallbackInfo ci) throws ExecutionException, InterruptedException {
         // noinspection ConstantConditions - I think mixin is confusing for intellij here
         if (AntiResourceReload.cache == null || (Object) this != AntiResourceReload.cache.get()) {
-            instance.close();
+            ci.cancel();
         }
     }
 }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/ServerResourceManagerMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/ServerResourceManagerMixin.java
@@ -18,7 +18,7 @@ public abstract class ServerResourceManagerMixin {
     )
     private void keepCachedResourcesOpen(CallbackInfo ci) throws ExecutionException, InterruptedException {
         // noinspection ConstantConditions - I think mixin is confusing for intellij here
-        if (AntiResourceReload.cache == null || (Object) this != AntiResourceReload.cache.get()) {
+        if (AntiResourceReload.cache != null && (Object) this == AntiResourceReload.cache.get()) {
             ci.cancel();
         }
     }

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "me.wurgo.antiresourcereload.mixin",
   "compatibilityLevel": "JAVA_8",
-  "mixins": [
+  "client": [
     "MinecraftClientMixin",
     "ServerResourceManagerMixin",
     "RecipeManagerAccess",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,11 +22,6 @@
   "mixins": [
     "antiresourcereload.mixins.json"
   ],
-  "entrypoints": {
-    "main": [
-      "me.wurgo.antiresourcereload.AntiResourceReload"
-    ]
-  },
   "depends": {
     "minecraft": ">=1.16 <=1.16.1",
     "fabricloader": ">=0.15.0"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
     "homepage": "https://github.com/wurgo"
   },
   "license": "MIT",
-  "environment": "*",
+  "environment": "client",
   "mixins": [
     "antiresourcereload.mixins.json"
   ],
@@ -28,7 +28,8 @@
     ]
   },
   "depends": {
-    "minecraft": ">=1.16 <=1.16.1"
+    "minecraft": ">=1.16 <=1.16.1",
+    "fabricloader": ">=0.15.0"
   },
   "breaks": {
     "speedrunigt": "<7.2"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "antiresourcereload.mixins.json"
   ],
   "depends": {
-    "minecraft": ">=1.16 <=1.16.1",
+    "minecraft": "1.16.1",
     "fabricloader": ">=0.15.0"
   },
   "breaks": {


### PR DESCRIPTION
- fix registry tags not being reloaded if datapacks are used between non-datapack resets
- java 8 compat
- seedqueue compat
- misc cleanup