### PR TITLE
cache UserCache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.1-build.24
 loader_version=0.16.0
 
 # Mod Properties
-mod_version=5.0.0
+mod_version=5.1.0
 maven_group=me.wurgo
 archives_base_name=antiresourcereload
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx2G
 # check these on https://fabricmc.net/develop
 minecraft_version=1.16.1
 yarn_mappings=1.16.1-build.24
-loader_version=0.15.0
+loader_version=0.16.0
 
 # Mod Properties
 mod_version=5.0.0

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -3,6 +3,7 @@ package me.wurgo.antiresourcereload;
 import com.google.gson.JsonElement;
 import net.minecraft.resource.ServerResourceManager;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.UserCache;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -16,7 +17,9 @@ public class AntiResourceReload {
     public static Map<Identifier, JsonElement> recipes;
     public static boolean hasSeenRecipes;
 
+    public static UserCache userCache;
+
     public static void log(String message) {
-        LOGGER.info("[AntiResourceReload] " + message);
+        LOGGER.info("[AntiResourceReload] {}", message);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "minecraft": "1.16.1",
-    "fabricloader": ">=0.15.0"
+    "fabricloader": ">=0.16.0"
   },
   "breaks": {
     "speedrunigt": "<7.2"


### PR DESCRIPTION
There is only 3 places where the `UserCache` is ever created, `MinecraftClient#startIntegratedServer`, `MinecraftClient#joinWorld` and the dedicated server main method which we can ignore.
As long as AntiResourceReload uses the cache on both `startIntegratedServer` and `joinWorld`, no other `UserCache` instance will ever be created.
The `MinecraftServer.USER_CACHE_FILE` field is also only ever accessed from those 3 places
`MinecraftServer.USER_CACHE_FILE` is also the only mention of usercache as a string, so the file is never written to in any other way in Minecraft.
There is 3 occurances of UserCache#save, two in UserCache itself which are fine, one in MinecraftDedicatedServer#setupServer which ARR won't be loaded on.