### PR TITLE
5.2.0: Cache Structures & default Pack Metadata

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.1-build.24
 loader_version=0.16.0
 
 # Mod Properties
-mod_version=5.2.0-beta.1
+mod_version=5.2.0-beta.2
 maven_group=me.wurgo
 archives_base_name=antiresourcereload
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.1-build.24
 loader_version=0.16.0
 
 # Mod Properties
-mod_version=5.1.0
+mod_version=5.2.0-beta.1
 maven_group=me.wurgo
 archives_base_name=antiresourcereload
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.16.1-build.24
 loader_version=0.16.0
 
 # Mod Properties
-mod_version=5.2.0-beta.2
+mod_version=5.2.0
 maven_group=me.wurgo
 archives_base_name=antiresourcereload
 

--- a/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
+++ b/src/main/java/me/wurgo/antiresourcereload/AntiResourceReload.java
@@ -2,11 +2,14 @@ package me.wurgo.antiresourcereload;
 
 import com.google.gson.JsonElement;
 import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.structure.Structure;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.UserCache;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -18,6 +21,8 @@ public class AntiResourceReload {
     public static boolean hasSeenRecipes;
 
     public static UserCache userCache;
+
+    public static final Map<Identifier, Structure> structures = Collections.synchronizedMap(new HashMap<>());
 
     public static void log(String message) {
         LOGGER.info("[AntiResourceReload] {}", message);

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/DefaultResourcePackMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/DefaultResourcePackMixin.java
@@ -1,0 +1,28 @@
+package me.wurgo.antiresourcereload.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.resource.DefaultResourcePack;
+import net.minecraft.resource.metadata.PackResourceMetadata;
+import net.minecraft.resource.metadata.ResourceMetadataReader;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(DefaultResourcePack.class)
+public abstract class DefaultResourcePackMixin {
+    @Nullable
+    @Unique
+    private static PackResourceMetadata METADATA;
+
+    @WrapMethod(method = "parseMetadata")
+    private Object cacheMetadata(ResourceMetadataReader<?> reader, Operation<?> original) {
+        if (reader != PackResourceMetadata.READER) {
+            return original.call(reader);
+        }
+        if (METADATA == null) {
+            METADATA = (PackResourceMetadata) original.call(reader);
+        }
+        return METADATA;
+    }
+}

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/Structure$PalettedBlockInfoListMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/Structure$PalettedBlockInfoListMixin.java
@@ -1,7 +1,9 @@
 package me.wurgo.antiresourcereload.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.structure.Structure;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -11,14 +13,15 @@ import java.util.Map;
 @Mixin(Structure.PalettedBlockInfoList.class)
 public abstract class Structure$PalettedBlockInfoListMixin {
 
-    @ModifyExpressionValue(
+    @WrapOperation(
             method = "<init>*",
             at = @At(
-                    value = "INVOKE",
-                    target = "Lcom/google/common/collect/Maps;newHashMap()Ljava/util/HashMap;"
+                    value = "FIELD",
+                    target = "Lnet/minecraft/structure/Structure$PalettedBlockInfoList;blockToInfos:Ljava/util/Map;",
+                    opcode = Opcodes.PUTFIELD
             )
     )
-    private Map<?, ?> synchronizeBlockToInfosMap(Map<?, ?> blockToInfos) {
-        return Collections.synchronizedMap(blockToInfos);
+    private void synchronizeBlockToInfosMap(Structure.PalettedBlockInfoList list, Map<?, ?> blockToInfos, Operation<Void> original) {
+        original.call(list, Collections.synchronizedMap(blockToInfos));
     }
 }

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/Structure$PalettedBlockInfoListMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/Structure$PalettedBlockInfoListMixin.java
@@ -1,0 +1,24 @@
+package me.wurgo.antiresourcereload.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraft.structure.Structure;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Mixin(Structure.PalettedBlockInfoList.class)
+public abstract class Structure$PalettedBlockInfoListMixin {
+
+    @ModifyExpressionValue(
+            method = "<init>*",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lcom/google/common/collect/Maps;newHashMap()Ljava/util/HashMap;"
+            )
+    )
+    private Map<?, ?> synchronizeBlockToInfosMap(Map<?, ?> blockToInfos) {
+        return Collections.synchronizedMap(blockToInfos);
+    }
+}

--- a/src/main/java/me/wurgo/antiresourcereload/mixin/StructureManagerMixin.java
+++ b/src/main/java/me/wurgo/antiresourcereload/mixin/StructureManagerMixin.java
@@ -1,0 +1,40 @@
+package me.wurgo.antiresourcereload.mixin;
+
+import me.wurgo.antiresourcereload.AntiResourceReload;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.structure.Structure;
+import net.minecraft.structure.StructureManager;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.function.Function;
+
+@Mixin(StructureManager.class)
+public abstract class StructureManagerMixin {
+    @Shadow
+    private ResourceManager field_25189;
+
+    @ModifyArg(
+            method = "getStructure",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/Map;computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;"
+            ),
+            index = 1
+    )
+    private Function<Identifier, Structure> getCachedStructure(Function<Identifier, Structure> function) {
+        return id -> {
+            if (AntiResourceReload.cache != null) {
+                ServerResourceManager serverResourceManager = AntiResourceReload.cache.getNow(null);
+                if (serverResourceManager != null && serverResourceManager.getResourceManager() == this.field_25189) {
+                    return AntiResourceReload.structures.computeIfAbsent(id, function);
+                }
+            }
+            return function.apply(id);
+        };
+    }
+}

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -9,6 +9,7 @@
     "RecipeManagerAccess",
     "RecipeManagerMixin",
     "ServerResourceManagerMixin",
+    "Structure$PalettedBlockInfoListMixin",
     "StructureManagerMixin"
   ],
   "injectors": {

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -5,10 +5,11 @@
   "compatibilityLevel": "JAVA_8",
   "client": [
     "MinecraftClientMixin",
-    "ServerResourceManagerMixin",
+    "RecipeBookWidgetMixin",
     "RecipeManagerAccess",
     "RecipeManagerMixin",
-    "RecipeBookWidgetMixin"
+    "ServerResourceManagerMixin",
+    "StructureManagerMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/antiresourcereload.mixins.json
+++ b/src/main/resources/antiresourcereload.mixins.json
@@ -4,6 +4,7 @@
   "package": "me.wurgo.antiresourcereload.mixin",
   "compatibilityLevel": "JAVA_8",
   "client": [
+    "DefaultResourcePackMixin",
     "MinecraftClientMixin",
     "RecipeBookWidgetMixin",
     "RecipeManagerAccess",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,13 +9,15 @@
   ],
   "contributors": [
     "Pixfumy",
-    "KingContaria",
+    "contaria",
     "Ronkzinho",
     "jan-leila",
     "VoidXWalker"
   ],
   "contact": {
-    "homepage": "https://github.com/wurgo"
+    "homepage": "https://github.com/wurgo",
+    "sources": "https://github.com/Minecraft-Java-Edition-Speedrunning/antiresourcereload",
+    "issues": "https://github.com/Minecraft-Java-Edition-Speedrunning/antiresourcereload/issues"
   },
   "license": "MIT",
   "environment": "client",


### PR DESCRIPTION
- pack metadata caching is small but easy
- structures are usually lazily loaded, instead antiresourcereload now uses a cache if the structure manager uses the cached resource manager